### PR TITLE
fix: Java 17 用のプロファイルを追加

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,16 @@
         </plugins>
       </build>
     </profile>
+    <profile>
+      <id>java17</id>
+      <activation>
+        <jdk>17</jdk>
+      </activation>
+      <properties>
+        <!-- Java 17 で動かすときに MaxPermSize の指定があるとエラーになるので、設定を上書きして除去 -->
+        <junit.additionalArgLine></junit.additionalArgLine>
+      </properties>
+    </profile>
   </profiles>
 
   <dependencies>


### PR DESCRIPTION
`junit.additionalArgLine` プロパティで `MaxPermSize` という JVM オプションが設定されているが、このオプションは Java 17 では使用できなくなっているため、そのままだとエラーになる。

Java 17 用のプロファイルを追加して、 `junit.additionalArgLine` を空で上書きすることで対応。