### PR TITLE
fix: DBのバリエーションテストのときにプロファイルで追加される依存がwarの中に入らずエラーになっていた問題を修正

### DIFF
--- a/src/test/java/nablarch/fw/batch/ee/integration/BatchIntegrationTest.java
+++ b/src/test/java/nablarch/fw/batch/ee/integration/BatchIntegrationTest.java
@@ -10,6 +10,7 @@ import nablarch.core.repository.ObjectLoader;
 import nablarch.core.repository.SystemRepository;
 import nablarch.core.repository.di.DiContainer;
 import nablarch.core.repository.di.config.xml.XmlComponentDefinitionLoader;
+import nablarch.core.util.StringUtil;
 import nablarch.fw.batch.ee.JobExecutor;
 import nablarch.fw.batch.ee.initializer.RepositoryInitializer;
 import nablarch.fw.batch.ee.integration.app.FileWriter;
@@ -20,11 +21,9 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
-import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ArchivePath;
 import org.jboss.shrinkwrap.api.Filter;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.shrinkwrap.resolver.api.maven.Maven;
@@ -130,11 +129,14 @@ public class BatchIntegrationTest {
      * @return war アーカイブ
      */
     private static WebArchive buildWar(JavaArchive mainJar) {
+        final String dbProfile = System.getProperty("db-profile");
+        final String[] profiles = StringUtil.isNullOrEmpty(dbProfile) ? new String[0] : new String[] {dbProfile};
+
         final WebArchive archive = ShrinkWrap.create(WebArchive.class, "batch.war")
                 .addAsLibraries(
                         Maven.configureResolver()
                                 .workOffline()
-                                .loadPomFromFile("pom.xml")
+                                .loadPomFromFile("pom.xml", profiles)
                                 .importCompileAndRuntimeDependencies()
                                 .importTestDependencies()
                                 .resolve()


### PR DESCRIPTION
## エラー内容

CI環境でDBのバリエーションテストを行うときに、Arquillianのテストで以下のエラーが発生した。

```
[ERROR] executeChunk_Success(nablarch.fw.batch.ee.integration.BatchIntegrationTest)  Time elapsed: 0.088 s  <<< ERROR!
nablarch.core.repository.di.ConfigurationLoadException: file processing failed. file = classpath:db-default.xml
	at deployment.batch.war//nablarch.fw.batch.ee.integration.BatchIntegrationTest.setUpClass(BatchIntegrationTest.java:214)
	at deployment.batch.war//nablarch.fw.batch.ee.integration.BatchIntegrationTest.setUp(BatchIntegrationTest.java:224)
Caused by: nablarch.core.repository.di.ConfigurationLoadException: component class load failed. component class name = oracle.jdbc.xa.client.OracleXADataSource
	at deployment.batch.war//nablarch.fw.batch.ee.integration.BatchIntegrationTest.setUpClass(BatchIntegrationTest.java:214)
	at deployment.batch.war//nablarch.fw.batch.ee.integration.BatchIntegrationTest.setUp(BatchIntegrationTest.java:224)
Caused by: java.lang.ClassNotFoundException: oracle.jdbc.xa.client.OracleXADataSource from [Module "deployment.batch.war" from Service Module Loader]
	at deployment.batch.war//nablarch.fw.batch.ee.integration.BatchIntegrationTest.setUpClass(BatchIntegrationTest.java:214)
	at deployment.batch.war//nablarch.fw.batch.ee.integration.BatchIntegrationTest.setUp(BatchIntegrationTest.java:224)
```

## 原因

テスト対象のコードを war にアーカイブして Arqullian で起動する Wildfly にデプロイするが、その中に DB のバリエーションテスト用のプロファイルで追加される JDBC ドライバの依存が含まれていないため。

```java
    private static WebArchive buildWar(JavaArchive mainJar) {
        final WebArchive archive = ShrinkWrap.create(WebArchive.class, "batch.war")
                .addAsLibraries(
                        Maven.configureResolver()
                                .workOffline()
                                .loadPomFromFile("pom.xml")
    ...
```

`loadPomFromFile` で `pom.xml` に書かれた依存関係を解決しているが、プロファイルの指定が考慮されていないため DB バリエーションテストでのみエラーとなった。

※組み込みGlassFishを使っていたときは、JUnitを実行しているものと同じクラスローダー上でGlassFishが起動されていたのでプロファイルで追加された依存関係も問題なく利用できていた。

## 対応内容

`loadPomFromFile` は第二引数にプロファイルを渡すことができるので、DBバリエーションテストのときに指定されたプロファイルのIDを渡すように修正。
プロファイルのIDは、 nablarch-parent でプロファイルごとに JUnit 実行時に渡すシステムプロパティを追加することで連携できるようにした。
（nablarch-fw-batch-ee 側だけで現在のDB設定からプロファイルIDを解決して設定する方法も考えたが、それをすると今後DBが増えるたびに nablarch-fw-batch-ee も修正が必要になるためやめておいた）

